### PR TITLE
Raise `ValueError` when parameter for GLM_single is misspelled

### DIFF
--- a/glmsingle/glmsingle.py
+++ b/glmsingle/glmsingle.py
@@ -1,11 +1,14 @@
 from __future__ import absolute_import, division, print_function
 import os
+import warnings
+
 import numpy as np
 from tqdm import tqdm
 import matplotlib.pyplot as plt
 from sklearn.preprocessing import normalize
 from glmsingle.check_inputs import check_inputs
 from glmsingle.defaults import default_params
+import h5py
 from glmsingle.gmm.findtailthreshold import findtailthreshold
 from glmsingle.hrf.gethrf import getcanonicalhrf, getcanonicalhrflibrary
 from glmsingle.hrf.normalisemax import normalisemax
@@ -260,6 +263,12 @@ class GLM_single():
         for key, _ in default_params.items():
             if key not in params.keys():
                 params[key] = default_params[key]
+        for key in params.keys():
+            if key not in default_params.keys():
+                raise ValueError(f"""
+                Input parameter not recognized: '{key}'
+                Possible input parameters are:\n{list(default_params.keys())}
+                """)
 
         self.params = params
 
@@ -585,6 +594,7 @@ class GLM_single():
             file0 = os.path.join(outputdir, 'TYPEA_ONOFF.npy')
             print(f'\n*** Saving results to {file0}. ***\n')
             np.save(file0, onoffR2, meanvol, xyz)
+
 
         # figures
         if wantfig:

--- a/glmsingle/glmsingle.py
+++ b/glmsingle/glmsingle.py
@@ -1,14 +1,11 @@
 from __future__ import absolute_import, division, print_function
 import os
-import warnings
-
 import numpy as np
 from tqdm import tqdm
 import matplotlib.pyplot as plt
 from sklearn.preprocessing import normalize
 from glmsingle.check_inputs import check_inputs
 from glmsingle.defaults import default_params
-import h5py
 from glmsingle.gmm.findtailthreshold import findtailthreshold
 from glmsingle.hrf.gethrf import getcanonicalhrf, getcanonicalhrflibrary
 from glmsingle.hrf.normalisemax import normalisemax
@@ -594,7 +591,6 @@ class GLM_single():
             file0 = os.path.join(outputdir, 'TYPEA_ONOFF.npy')
             print(f'\n*** Saving results to {file0}. ***\n')
             np.save(file0, onoffR2, meanvol, xyz)
-
 
         # figures
         if wantfig:

--- a/glmsingle/glmsingle.py
+++ b/glmsingle/glmsingle.py
@@ -269,7 +269,7 @@ class GLM_single():
             if key not in allowed:
                 raise ValueError(f"""
                 Input parameter not recognized: '{key}'
-                Possible input parameters are:\n{list(default_params.keys())}
+                Possible input parameters are:\n{allowed}
                 """)
 
         self.params = params

--- a/glmsingle/glmsingle.py
+++ b/glmsingle/glmsingle.py
@@ -96,7 +96,7 @@ class GLM_single():
          1 means perform ridge regression
          Default: 1.
 
-       <chunknum> (optional) is the number of voxels that we will process at
+       <chunklen> (optional) is the number of voxels that we will process at
          the same time. This number should be large in order to speed
          computation, but should not be so large that you run out of RAM.
          Default: 50000.
@@ -139,7 +139,7 @@ class GLM_single():
 
         *** GLM FLAGS ***
 
-        <extraregressors> (optional) is time x regressors or a cell vector
+        <extra_regressors> (optional) is time x regressors or a cell vector
          of elements that are each time x regressors. The dimensions of
          <extraregressors> should mirror that of <design> (i.e. same number of
          runs, same number of time points). The number of extra regressors
@@ -260,8 +260,13 @@ class GLM_single():
         for key, _ in default_params.items():
             if key not in params.keys():
                 params[key] = default_params[key]
+
+        # Check if all opt arguments are allowed
+        allowed = list(default_params.keys()) + [
+            'xvalscheme', 'sessionindicator', 'hrflibrary', 'hrftoassume', 'maxpolydeg'
+        ]
         for key in params.keys():
-            if key not in default_params.keys():
+            if key not in allowed:
                 raise ValueError(f"""
                 Input parameter not recognized: '{key}'
                 Possible input parameters are:\n{list(default_params.keys())}


### PR DESCRIPTION
Just a minor suggestion after our discussion on potentially mixing up 'chunknum' and 'chunklen'. Any spelling mistakes would now stop the user before running `.fit()`.

Example
```
from glmsingle.glmsingle import GLM_single
gs = GLM_single(params=dict(
    chunknumber=1000,
))

```
```
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-8-74015f237f63> in <module>
      1 from glmsingle.glmsingle import GLM_single
----> 2 gs = GLM_single(params=dict(
      3     chunknumber=1000,
      4 ))

/LOCAL/ocontier/thingsmri/bids/code/external_libraries/GLMsingle/glmsingle/glmsingle.py in __init__(self, params)
    266                 Input parameter not recognized: '{key}'
    267                 Possible input parameters are:\n{list(default_params.keys())}
--> 268                 """)
    269 
    270         self.params = params

ValueError: 
                Input parameter not recognized: 'chunknumber'
                Possible input parameters are:
['numforhrf', 'hrfthresh', 'hrffitmask', 'R2thresh', 'hrfmodel', 'n_jobs', 'n_pcs', 'n_boots', 'extra_regressors', 'wantlibrary', 'wantglmdenoise', 'wantfracridge', 'chunklen', 'wantfileoutputs', 'wantmemoryoutputs', 'wantparametric', 'wantpercentbold', 'wantlss', 'brainthresh', 'brainR2', 'brainexclude', 'pcR2cutoff', 'pcR2cutoffmask', 'pcstop', 'fracs', 'wantautoscale', 'seed', 'suppressoutput', 'lambda']
```