### PR TITLE
change back to the previous commit

### DIFF
--- a/glmsingle/glmsingle.py
+++ b/glmsingle/glmsingle.py
@@ -441,9 +441,10 @@ class GLM_single():
 
         if 'maxpolydeg' not in params:
             params['maxpolydeg'] = [
+                np.arange(
                     alt_round(
-                        ((self.data[r].shape[-1]*tr)/60)/2)
-                    for r in np.arange(numruns)]
+                        ((self.data[r].shape[-1]*tr)/60)/2) + 1
+                    ) for r in np.arange(numruns)]
 
         if 'hrftoassume' not in params:
             params['hrftoassume'] = normalisemax(


### PR DESCRIPTION
The input `maxpolydeg` is required to be a non-negative integer, and function `make_polynomial_matrix(n, degrees)` requires variable `degrees` as an array for each run, thus `np.arange` is needed when we construct `params['maxpolydeg']`. So the previous code was correct, I don't know why previous commit changed it.